### PR TITLE
fix: allow plugin to have no webhooks

### DIFF
--- a/src/main/java/net/getsentry/gocd/webhooknotifier/executors/GetPluginConfigurationExecutor.java
+++ b/src/main/java/net/getsentry/gocd/webhooknotifier/executors/GetPluginConfigurationExecutor.java
@@ -32,7 +32,7 @@ public class GetPluginConfigurationExecutor implements RequestExecutor {
 
     private static final Gson GSON = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
 
-    public static final Field WEBHOOK_URLS = new NonBlankField("webhook_urls", "List of webhook URLs seperated by new lines.", null, true, false, "0");
+    public static final Field WEBHOOK_URLS = new NonBlankField("webhook_urls", "List of webhook URLs seperated by new lines.", null, false, false, "0");
 
     public static final Map<String, Field> FIELDS = new LinkedHashMap<>();
 

--- a/src/main/resources/plugin-settings.template.html
+++ b/src/main/resources/plugin-settings.template.html
@@ -20,7 +20,7 @@ Ensure that the keys you use are also declared in the GetPluginConfigurationExec
 TODO: change this to your needs
 -->
 <div class="form_item_block">
-  <label>WebHook URL:<span class='asterix'>*</span></label>
+  <label>WebHook URLs (ensure each URL is on a seperate line):</label>
   <textarea type="text" ng-model="webhook_urls" ng-required="true"></textarea>
   <span class="form_error" ng-show="GOINPUTNAME[webhook_urls].$error.server">{{GOINPUTNAME[webhook_urls].$error.server}}</span>
 </div>

--- a/src/test/java/net/getsentry/gocd/webhooknotifier/executors/GetPluginConfigurationExecutorTest.java
+++ b/src/test/java/net/getsentry/gocd/webhooknotifier/executors/GetPluginConfigurationExecutorTest.java
@@ -47,7 +47,7 @@ public class GetPluginConfigurationExecutorTest {
         String expectedJSON = "{\n" +
                 "  \"webhook_urls\": {\n" +
                 "    \"display-name\": \"List of webhook URLs seperated by new lines.\",\n" +
-                "    \"required\": true,\n" +
+                "    \"required\": false,\n" +
                 "    \"secure\": false,\n" +
                 "    \"display-order\": \"0\"\n" +
                 "  }\n" +


### PR DESCRIPTION
Useful if we want to turn notifications on/off easily during testing and rollout.