### PR TITLE
Switching to a simpler auth mechanism

### DIFF
--- a/src/main/java/net/getsentry/gocd/webhooknotifier/PluginSettings.java
+++ b/src/main/java/net/getsentry/gocd/webhooknotifier/PluginSettings.java
@@ -16,7 +16,6 @@
 
 package net.getsentry.gocd.webhooknotifier;
 
-import java.net.URI;
 import java.util.ArrayList;
 
 import com.google.gson.Gson;
@@ -31,32 +30,31 @@ public class PluginSettings {
             create();
 
     @Expose
-    @SerializedName("webhook_uris")
-    private String webhookURIsValue;
+    @SerializedName("webhooks")
+    private String webhooksValue;
 
     public static PluginSettings fromJSON(String json) {
         return GSON.fromJson(json, PluginSettings.class);
     }
 
-    public URI[] getWebhookURIs() {
-        ArrayList<URI> uris = new ArrayList<>();
-        String[] lines = webhookURIsValue.split("\n");
+    public URLAudiencePair[] getWebhooks() {
+        ArrayList<URLAudiencePair> urlAudiencePairs = new ArrayList<>();
+        String[] lines = webhooksValue.split("\n");
         for (int i = 0; i < lines.length; i++) {
             String line = lines[i].trim();
             if (line.length() > 0) {
                 try {
-                    URI parsedUri = new URI(line);
-                    // Only allow HTTPS URIs
-                    if (parsedUri.getScheme() == null || !parsedUri.getScheme().equals("https")) {
-                        System.out.println("URI must use HTTPS: " + line);
-                        continue;
+                    String[] parts = line.split(",");
+                    if (parts.length == 2) {
+                        urlAudiencePairs.add(new URLAudiencePair(parts[0].trim(), parts[1].trim()));
+                    } else {
+                        urlAudiencePairs.add(new URLAudiencePair(parts[0].trim(), null));
                     }
-                    uris.add(new URI(line));
                 } catch (Exception e) {
-                    System.out.println("Invalid URI: " + line);
+                    System.out.println("Error parsing webhook: " + line);
                 }
             }
         }
-        return uris.toArray(new URI[uris.size()]);
+        return urlAudiencePairs.toArray(new URLAudiencePair[urlAudiencePairs.size()]);
     }
 }

--- a/src/main/java/net/getsentry/gocd/webhooknotifier/URLAudiencePair.java
+++ b/src/main/java/net/getsentry/gocd/webhooknotifier/URLAudiencePair.java
@@ -1,0 +1,45 @@
+package net.getsentry.gocd.webhooknotifier;
+
+/**
+ * A pair of URL and audience where the audience is optional.
+ * If the audience is not provided, it will be used to authenticate with the GCP metadata server.
+ */
+public class URLAudiencePair {
+  private String url;
+  private String audience;
+
+  public URLAudiencePair(String url, String audience) {
+    this.url = url;
+    this.audience = audience;
+  }
+
+  public URLAudiencePair(String url) {
+    this(url, null);
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public String getAudience() {
+    return audience;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    URLAudiencePair that = (URLAudiencePair) o;
+
+    if (url != null ? !url.equals(that.url) : that.url != null) return false;
+    return audience != null ? audience.equals(that.audience) : that.audience == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = url != null ? url.hashCode() : 0;
+    result = 31 * result + (audience != null ? audience.hashCode() : 0);
+    return result;
+  }
+}

--- a/src/main/java/net/getsentry/gocd/webhooknotifier/URLAudiencePair.java
+++ b/src/main/java/net/getsentry/gocd/webhooknotifier/URLAudiencePair.java
@@ -1,15 +1,17 @@
 package net.getsentry.gocd.webhooknotifier;
 
+import java.net.URL;
+
 /**
  * A pair of URL and audience where the audience is optional.
  * If the audience is not provided, it will be used to authenticate with the GCP metadata server.
  */
 public class URLAudiencePair {
-  private String url;
+  private URL url;
   private String audience;
 
   public URLAudiencePair(String url, String audience) {
-    this.url = url;
+    this.url = validateURL(url);
     this.audience = audience;
   }
 
@@ -17,7 +19,7 @@ public class URLAudiencePair {
     this(url, null);
   }
 
-  public String getUrl() {
+  public URL getUrl() {
     return url;
   }
 
@@ -41,5 +43,18 @@ public class URLAudiencePair {
     int result = url != null ? url.hashCode() : 0;
     result = 31 * result + (audience != null ? audience.hashCode() : 0);
     return result;
+  }
+
+  private URL validateURL(String url) {
+    try {
+      URL parsedUrl = new URL(url);
+      if (!parsedUrl.getProtocol().equals("https")) {
+        throw new IllegalArgumentException("Only HTTPS URLs are supported");
+      } else {
+        return parsedUrl;
+      }
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Invalid URL: " + url);
+    }
   }
 }

--- a/src/main/java/net/getsentry/gocd/webhooknotifier/executors/GetPluginConfigurationExecutor.java
+++ b/src/main/java/net/getsentry/gocd/webhooknotifier/executors/GetPluginConfigurationExecutor.java
@@ -32,12 +32,12 @@ public class GetPluginConfigurationExecutor implements RequestExecutor {
 
     private static final Gson GSON = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
 
-    public static final Field WEBHOOK_URIS = new Field("webhook_uris", "List of URIs seperated by new lines.", null, false, false, "0");
+    public static final Field WEBHOOKS = new Field("webhooks", "List of URLs seperated by new lines.", null, false, false, "0");
 
     public static final Map<String, Field> FIELDS = new LinkedHashMap<>();
 
     static {
-        FIELDS.put(WEBHOOK_URIS.key(), WEBHOOK_URIS);
+        FIELDS.put(WEBHOOKS.key(), WEBHOOKS);
     }
 
     public GoPluginApiResponse execute() {

--- a/src/main/java/net/getsentry/gocd/webhooknotifier/utils/Http.java
+++ b/src/main/java/net/getsentry/gocd/webhooknotifier/utils/Http.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.URL;
 
 public class Http {
   protected static final String GCP_AUTH_METADATA_URL = "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=";
@@ -52,7 +53,7 @@ public class Http {
     for (URLAudiencePair urlAudiencePair : urlAudiencePairs) {
       try {
         List<Header> headers = new ArrayList<Header>();
-        String url = urlAudiencePair.getUrl();
+        URL url = urlAudiencePair.getUrl();
         if (url == null) {
           continue;
         }
@@ -73,9 +74,9 @@ public class Http {
     pingWebhooks(pluginRequest, type, originalPayload, httpClient);
   }
 
-  protected static HttpResponse post(String endpoint, String requestBody, HttpClient client, Header... headers)
+  protected static HttpResponse post(URL endpoint, String requestBody, HttpClient client, Header... headers)
       throws UnsupportedEncodingException, IOException {
-    HttpPost post = new HttpPost(endpoint);
+    HttpPost post = new HttpPost(endpoint.toString());
     post.setEntity(new StringEntity(requestBody));
     post.setHeader("Content-type", "application/json");
     for (Header header : headers) {
@@ -84,7 +85,7 @@ public class Http {
     return client.execute(post);
   }
 
-  protected static HttpResponse post(String endpoint, String requestBody, Header... headers)
+  protected static HttpResponse post(URL endpoint, String requestBody, Header... headers)
       throws UnsupportedEncodingException, IOException {
     HttpClient httpClient = HttpClientBuilder.create().build();
     return post(endpoint, requestBody, httpClient, headers);

--- a/src/main/resources/plugin-settings.template.html
+++ b/src/main/resources/plugin-settings.template.html
@@ -20,7 +20,7 @@ Ensure that the keys you use are also declared in the GetPluginConfigurationExec
 TODO: change this to your needs
 -->
 <div class="form_item_block">
-  <label>URI for the webhook to be called and optionally the service account via userinfo (NOTE: each URI should be on a separate line)</label>
-  <textarea type="text" ng-model="webhook_uris" ng-required="true"></textarea>
-  <span class="form_error" ng-show="GOINPUTNAME[webhook_uris].$error.server">{{GOINPUTNAME[webhook_uris].$error.server}}</span>
+  <label>URL for the webhook to be called and optionally an audience used to authenticate with a comma separating the two values (and non comma if no audience is provided) (NOTE: each URL audience pair should be on a separate line)</label>
+  <textarea type="text" ng-model="webhooks" ng-required="true"></textarea>
+  <span class="form_error" ng-show="GOINPUTNAME[webhooks].$error.server">{{GOINPUTNAME[webhooks].$error.server}}</span>
 </div>

--- a/src/test/java/net/getsentry/gocd/webhooknotifier/PluginSettingsTest.java
+++ b/src/test/java/net/getsentry/gocd/webhooknotifier/PluginSettingsTest.java
@@ -21,21 +21,35 @@ import org.junit.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 
-import java.net.URI;
-
 public class PluginSettingsTest {
     @Test
     public void shouldDeserializeFromJSON() throws Exception {
         PluginSettings pluginSettings = PluginSettings.fromJSON("{" +
-                "\"webhook_uris\": \"https://api.example.com \n     \n https://api-2.example.com \"" +
+                "\"webhooks\": \"https://api.example.com \n     \n https://api-2.example.com \"" +
                 "}");
 
         assertThat(
-            "WebHook URIs",
-            pluginSettings.getWebhookURIs(),
+            "WebHooks",
+            pluginSettings.getWebhooks(),
             arrayContainingInAnyOrder(
-                URI.create("https://api.example.com"),
-                URI.create("https://api-2.example.com")
+                new URLAudiencePair("https://api.example.com"),
+                new URLAudiencePair("https://api-2.example.com")
+            )
+        );
+    }
+
+    @Test
+    public void shouldDeserializeFromJSONWithAudience() throws Exception {
+        PluginSettings pluginSettings = PluginSettings.fromJSON("{" +
+                "\"webhooks\": \"https://api.example.com,audience1 \n     \n https://api-2.example.com,audience2 \"" +
+                "}");
+
+        assertThat(
+            "WebHooks",
+            pluginSettings.getWebhooks(),
+            arrayContainingInAnyOrder(
+                new URLAudiencePair("https://api.example.com", "audience1"),
+                new URLAudiencePair("https://api-2.example.com", "audience2")
             )
         );
     }

--- a/src/test/java/net/getsentry/gocd/webhooknotifier/PluginSettingsTest.java
+++ b/src/test/java/net/getsentry/gocd/webhooknotifier/PluginSettingsTest.java
@@ -23,19 +23,30 @@ import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 
 public class PluginSettingsTest {
     @Test
+    public void shouldFailToDeserializeHttp() throws Exception {
+        PluginSettings pluginSettings = PluginSettings.fromJSON("{" +
+                "\"webhooks\": \"http://api.example.com \n     \n https://api-2.example.com \"" +
+                "}");
+
+        assertThat(
+                "WebHooks",
+                pluginSettings.getWebhooks(),
+                arrayContainingInAnyOrder(
+                        new URLAudiencePair("https://api-2.example.com")));
+    }
+
+    @Test
     public void shouldDeserializeFromJSON() throws Exception {
         PluginSettings pluginSettings = PluginSettings.fromJSON("{" +
                 "\"webhooks\": \"https://api.example.com \n     \n https://api-2.example.com \"" +
                 "}");
 
         assertThat(
-            "WebHooks",
-            pluginSettings.getWebhooks(),
-            arrayContainingInAnyOrder(
-                new URLAudiencePair("https://api.example.com"),
-                new URLAudiencePair("https://api-2.example.com")
-            )
-        );
+                "WebHooks",
+                pluginSettings.getWebhooks(),
+                arrayContainingInAnyOrder(
+                        new URLAudiencePair("https://api.example.com"),
+                        new URLAudiencePair("https://api-2.example.com")));
     }
 
     @Test
@@ -45,12 +56,10 @@ public class PluginSettingsTest {
                 "}");
 
         assertThat(
-            "WebHooks",
-            pluginSettings.getWebhooks(),
-            arrayContainingInAnyOrder(
-                new URLAudiencePair("https://api.example.com", "audience1"),
-                new URLAudiencePair("https://api-2.example.com", "audience2")
-            )
-        );
+                "WebHooks",
+                pluginSettings.getWebhooks(),
+                arrayContainingInAnyOrder(
+                        new URLAudiencePair("https://api.example.com", "audience1"),
+                        new URLAudiencePair("https://api-2.example.com", "audience2")));
     }
 }

--- a/src/test/java/net/getsentry/gocd/webhooknotifier/executors/GetPluginConfigurationExecutorTest.java
+++ b/src/test/java/net/getsentry/gocd/webhooknotifier/executors/GetPluginConfigurationExecutorTest.java
@@ -45,8 +45,8 @@ public class GetPluginConfigurationExecutorTest {
 
         assertThat(response.responseCode(), CoreMatchers.is(200));
         String expectedJSON = "{\n" +
-                "  \"webhook_uris\": {\n" +
-                "    \"display-name\": \"List of URIs seperated by new lines.\",\n" +
+                "  \"webhooks\": {\n" +
+                "    \"display-name\": \"List of URLs seperated by new lines.\",\n" +
                 "    \"required\": false,\n" +
                 "    \"secure\": false,\n" +
                 "    \"display-order\": \"0\"\n" +

--- a/src/test/java/net/getsentry/gocd/webhooknotifier/executors/ValidateConfigurationExecutorTest.java
+++ b/src/test/java/net/getsentry/gocd/webhooknotifier/executors/ValidateConfigurationExecutorTest.java
@@ -37,7 +37,7 @@ public class ValidateConfigurationExecutorTest {
     @Test
     public void shouldValidateAGoodConfiguration() throws Exception {
         ValidatePluginSettings settings = new ValidatePluginSettings();
-        settings.put("webhook_uris", "https://api.example.com\nhttps://api-2.example.com");
+        settings.put("webhooks", "https://api.example.com\nhttps://api-2.example.com");
         GoPluginApiResponse response = new ValidateConfigurationExecutor(settings).execute();
 
         assertThat(response.responseCode(), is(200));
@@ -45,9 +45,9 @@ public class ValidateConfigurationExecutorTest {
     }
 
     @Test
-    public void shouldValidateConfigurationWithValidUserInfo() throws Exception {
+    public void shouldValidateConfigurationWithValidAudience() throws Exception {
         ValidatePluginSettings settings = new ValidatePluginSettings();
-        settings.put("webhook_uris", "https://me@example.com@example-webhook.com");
+        settings.put("webhooks", "https://example-webhook.com,fakeAudience");
         GoPluginApiResponse response = new ValidateConfigurationExecutor(settings).execute();
 
         assertThat(response.responseCode(), is(200));

--- a/src/test/java/net/getsentry/gocd/webhooknotifier/utils/HttpTest.java
+++ b/src/test/java/net/getsentry/gocd/webhooknotifier/utils/HttpTest.java
@@ -21,6 +21,7 @@ import org.apache.http.client.methods.HttpPost;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.URL;
 
 public class HttpTest {
     @Test
@@ -29,7 +30,7 @@ public class HttpTest {
         HttpResponse mockResponse = mock(HttpResponse.class);
         when(mockClient.execute(any())).thenReturn(mockResponse);
 
-        HttpResponse response = Http.post("https://example.com", "fakeData", mockClient);
+        HttpResponse response = Http.post(new URL("https://example.com"), "fakeData", mockClient);
 
         verify(mockClient).execute(any(HttpPost.class));
         assertThat(response, is(mockResponse));

--- a/src/test/java/net/getsentry/gocd/webhooknotifier/utils/HttpTest.java
+++ b/src/test/java/net/getsentry/gocd/webhooknotifier/utils/HttpTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import net.getsentry.gocd.webhooknotifier.PluginRequest;
 import net.getsentry.gocd.webhooknotifier.PluginSettings;
 import net.getsentry.gocd.webhooknotifier.ServerRequestFailedException;
+import net.getsentry.gocd.webhooknotifier.URLAudiencePair;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -20,8 +21,6 @@ import org.apache.http.client.methods.HttpPost;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.net.URISyntaxException;
 
 public class HttpTest {
     @Test
@@ -37,17 +36,17 @@ public class HttpTest {
     }
 
     @Test
-    public void testGetAuthTokenException() throws URISyntaxException, IOException {
+    public void testGetAuthTokenException() throws IOException {
         HttpClient mockClient = mock(HttpClient.class);
         when(mockClient.execute(HttpGet.class.cast(any()))).thenThrow(new IOException());
 
-        String authToken = Http.getAuthToken(new URI("https://user%40example.com@example.com"), mockClient);
+        String authToken = Http.getAuthToken(new URLAudiencePair("https://example.com", "fakeAudience"), mockClient);
 
         assertThat(authToken, is(nullValue()));
     }
 
     @Test
-    public void testGetAuthToken() throws URISyntaxException, IOException {
+    public void testGetAuthToken() throws IOException {
         HttpClient mockClient = mock(HttpClient.class);
         HttpResponse mockResponse = mock(HttpResponse.class);
         HttpEntity mockHttpEntity = mock(HttpEntity.class);
@@ -56,11 +55,11 @@ public class HttpTest {
         when(mockHttpEntity.getContent()).thenReturn(new ByteArrayInputStream("fakeToken".getBytes()));
         when(mockClient.execute(any())).thenReturn(mockResponse);
 
-        String authToken = Http.getAuthToken(new URI("https://user%40example.com@example.com"), mockClient);
+        String authToken = Http.getAuthToken(new URLAudiencePair("https://example.com", "fakeAudience"), mockClient);
 
         verify(mockClient).execute(argThat((HttpGet request) -> {
             try {
-                return request.getURI().toString().equals(Http.GCP_AUTH_METADATA_URL + "https://example.com");
+                return request.getURI().toString().equals(Http.GCP_AUTH_METADATA_URL + "fakeAudience");
             } catch (Exception e) {
                 return false;
             }
@@ -69,7 +68,7 @@ public class HttpTest {
     }
 
     @Test
-    public void testPingWebhooksFirstInstall() throws URISyntaxException, IOException, ServerRequestFailedException {
+    public void testPingWebhooksFirstInstall() throws IOException, ServerRequestFailedException {
         HttpClient mockClient = mock(HttpClient.class);
         PluginRequest mockPluginRequest = mock(PluginRequest.class);
         when(mockPluginRequest.getPluginSettings()).thenReturn(null);
@@ -81,11 +80,11 @@ public class HttpTest {
     }
 
     @Test
-    public void testPingWebhooksWithAuthToken() throws URISyntaxException, IOException, ServerRequestFailedException {
+    public void testPingWebhooksWithAuthToken() throws IOException, ServerRequestFailedException {
         HttpClient mockClient = mock(HttpClient.class);
         PluginRequest mockPluginRequest = mock(PluginRequest.class);
         PluginSettings mockPluginSettings = mock(PluginSettings.class);
-        when(mockPluginSettings.getWebhookURIs()).thenReturn(new URI[] { new URI("https://user%40example.com@example.com") });
+        when(mockPluginSettings.getWebhooks()).thenReturn(new URLAudiencePair[] { new URLAudiencePair("https://example.com", "fakeAudience") });
         when(mockPluginRequest.getPluginSettings()).thenReturn(mockPluginSettings);
 
         HttpResponse mockGetResponse = mock(HttpResponse.class);
@@ -103,7 +102,7 @@ public class HttpTest {
             if (request instanceof HttpGet) {
                 HttpGet getRequest = (HttpGet) request;
                 try {
-                    return getRequest.getURI().toString().equals(Http.GCP_AUTH_METADATA_URL + "https://example.com");
+                    return getRequest.getURI().toString().equals(Http.GCP_AUTH_METADATA_URL + "fakeAudience");
                 } catch (Exception e) {
                     return false;
                 }
@@ -124,11 +123,11 @@ public class HttpTest {
     }
 
     @Test
-    public void testPingWebhooks() throws URISyntaxException, IOException, ServerRequestFailedException {
+    public void testPingWebhooks() throws IOException, ServerRequestFailedException {
         HttpClient mockClient = mock(HttpClient.class);
         PluginRequest mockPluginRequest = mock(PluginRequest.class);
         PluginSettings mockPluginSettings = mock(PluginSettings.class);
-        when(mockPluginSettings.getWebhookURIs()).thenReturn(new URI[] { new URI("https://example.com") });
+        when(mockPluginSettings.getWebhooks()).thenReturn(new URLAudiencePair[] { new URLAudiencePair("https://example.com") });
         when(mockPluginRequest.getPluginSettings()).thenReturn(mockPluginSettings);
 
         Http.pingWebhooks(mockPluginRequest, "stage", "fakeData", mockClient);
@@ -143,11 +142,11 @@ public class HttpTest {
     }
 
     @Test
-    public void testPingWebhooksMultiple() throws URISyntaxException, IOException, ServerRequestFailedException {
+    public void testPingWebhooksMultiple() throws IOException, ServerRequestFailedException {
         HttpClient mockClient = mock(HttpClient.class);
         PluginRequest mockPluginRequest = mock(PluginRequest.class);
         PluginSettings mockPluginSettings = mock(PluginSettings.class);
-        when(mockPluginSettings.getWebhookURIs()).thenReturn(new URI[] { new URI("https://example.com"), new URI("https://example2.com") });
+        when(mockPluginSettings.getWebhooks()).thenReturn(new URLAudiencePair[] { new URLAudiencePair("https://example.com"), new URLAudiencePair("https://example2.com") });
         when(mockPluginRequest.getPluginSettings()).thenReturn(mockPluginSettings);
 
         Http.pingWebhooks(mockPluginRequest, "stage", "fakeData", mockClient);
@@ -162,11 +161,11 @@ public class HttpTest {
     }
 
     @Test
-    public void testPingWebhooksException() throws URISyntaxException, IOException, ServerRequestFailedException {
+    public void testPingWebhooksException() throws IOException, ServerRequestFailedException {
         HttpClient mockClient = mock(HttpClient.class);
         PluginRequest mockPluginRequest = mock(PluginRequest.class);
         PluginSettings mockPluginSettings = mock(PluginSettings.class);
-        when(mockPluginSettings.getWebhookURIs()).thenReturn(new URI[] { new URI("https://example.com") });
+        when(mockPluginSettings.getWebhooks()).thenReturn(new URLAudiencePair[] { new URLAudiencePair("https://example.com") });
         when(mockPluginRequest.getPluginSettings()).thenReturn(mockPluginSettings);
         doThrow(new IOException()).when(mockClient).execute(any());
 


### PR DESCRIPTION
Currently, the auth mechanism we have in place for this plugin only supports cloud function invocation. A more versatile implementation would allow the user to provide a webhook url and an audience to use rather than assume the url itself is the audience. While this doesn't enable us to specify which service account we want to use, currently we only use the default service account and don't plan to change that. Additionally, while this does add some custom parsing logic, it is simple enough and shouldn't cause any issues.