### PR TITLE
fix(dates): Adding a temp fix for date formats

### DIFF
--- a/src/main/java/net/getsentry/gocd/webhooknotifier/utils/DefaultDateTypeAdapter.java
+++ b/src/main/java/net/getsentry/gocd/webhooknotifier/utils/DefaultDateTypeAdapter.java
@@ -30,7 +30,7 @@ public class DefaultDateTypeAdapter implements JsonSerializer<Date>, JsonDeseria
     @Override
     public JsonElement serialize(Date src, Type typeOfSrc, JsonSerializationContext context) {
         synchronized (localFormat) {
-            String dateFormatAsString = enUsFormat.format(src);
+            String dateFormatAsString = enUsFormat.format(src).replaceAll(String.valueOf((char) 8239), " ");
             return new JsonPrimitive(dateFormatAsString);
         }
     }

--- a/src/main/java/net/getsentry/gocd/webhooknotifier/utils/DefaultDateTypeAdapter.java
+++ b/src/main/java/net/getsentry/gocd/webhooknotifier/utils/DefaultDateTypeAdapter.java
@@ -30,6 +30,7 @@ public class DefaultDateTypeAdapter implements JsonSerializer<Date>, JsonDeseria
     @Override
     public JsonElement serialize(Date src, Type typeOfSrc, JsonSerializationContext context) {
         synchronized (localFormat) {
+            // TODO: temporary hack to address https://stackoverflow.com/questions/77225936/java-21-problem-with-dateformat-getdatetimeinstance-formatnew-date/77226045#77226045
             String dateFormatAsString = enUsFormat.format(src).replaceAll(String.valueOf((char) 8239), " ");
             return new JsonPrimitive(dateFormatAsString);
         }


### PR DESCRIPTION
This is a short term fix that mitigates an issue when we updated our version of GoCD to use Java 21.