### PR TITLE
fix(serialization): Fixing serialization of dates

### DIFF
--- a/src/main/java/net/getsentry/gocd/webhooknotifier/utils/DefaultDateTypeAdapter.java
+++ b/src/main/java/net/getsentry/gocd/webhooknotifier/utils/DefaultDateTypeAdapter.java
@@ -30,8 +30,7 @@ public class DefaultDateTypeAdapter implements JsonSerializer<Date>, JsonDeseria
     @Override
     public JsonElement serialize(Date src, Type typeOfSrc, JsonSerializationContext context) {
         synchronized (localFormat) {
-            // TODO: temporary hack to address https://stackoverflow.com/questions/77225936/java-21-problem-with-dateformat-getdatetimeinstance-formatnew-date/77226045#77226045
-            String dateFormatAsString = enUsFormat.format(src).replaceAll(String.valueOf((char) 8239), " ");
+            String dateFormatAsString = enUsFormat.format(src);
             return new JsonPrimitive(dateFormatAsString);
         }
     }

--- a/src/main/java/net/getsentry/gocd/webhooknotifier/utils/Http.java
+++ b/src/main/java/net/getsentry/gocd/webhooknotifier/utils/Http.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
+
 public class Http {
   private static final String DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
   protected static final String SIGNATURE_HEADER = "x-gocd-signature";

--- a/src/main/java/net/getsentry/gocd/webhooknotifier/utils/Http.java
+++ b/src/main/java/net/getsentry/gocd/webhooknotifier/utils/Http.java
@@ -20,18 +20,21 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.FieldNamingPolicy;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
-
 public class Http {
+  private static final String DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
   protected static final String SIGNATURE_HEADER = "x-gocd-signature";
   protected static final String GCP_AUTH_METADATA_URL = "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=";
 
-  private static final Gson GSON = new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+  private static final Gson GSON = new GsonBuilder()
+      .registerTypeAdapter(Date.class, new DefaultDateTypeAdapter(DATE_PATTERN))
+      .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
       .create();
 
   public static void pingWebhooks(PluginRequest pluginRequest, String type, Object originalPayload, HttpClient client)

--- a/src/test/java/net/getsentry/gocd/webhooknotifier/utils/HttpTest.java
+++ b/src/test/java/net/getsentry/gocd/webhooknotifier/utils/HttpTest.java
@@ -1,5 +1,7 @@
 package net.getsentry.gocd.webhooknotifier.utils;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import net.getsentry.gocd.webhooknotifier.PluginRequest;
@@ -24,12 +26,20 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
-import java.text.DateFormat;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.util.TimeZone;
 
 public class HttpTest {
-    private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
+    @Before
+    public void setUp() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    }
+
+    @After
+    public void tearDown() {
+        TimeZone.setDefault(TimeZone.getDefault());
+    }
 
     @Test
     public void testPost() throws UnsupportedEncodingException, IOException {
@@ -108,19 +118,188 @@ public class HttpTest {
         when(mockPluginSettings.getWebhooks()).thenReturn(new URLWithAuth[] { new URLWithAuth("https://example.com") });
         when(mockPluginRequest.getPluginSettings()).thenReturn(mockPluginSettings);
 
-        StageStatusRequest stageStatusRequest = mock(StageStatusRequest.class);
-        stageStatusRequest.pipeline = mock(StageStatusRequest.Pipeline.class);
-        stageStatusRequest.pipeline.stage = mock(StageStatusRequest.Stage.class);
-        stageStatusRequest.pipeline.stage.createTime = DATE_FORMAT.parse("2021-01-01 10:12:00 AM");
+        String json = "{\n" +
+                "  \"pipeline\": {\n" +
+                "    \"name\": \"pipeline-name\",\n" +
+                "    \"counter\": \"1\",\n" +
+                "    \"group\": \"pipeline-group\",\n" +
+                "    \"build-cause\": [\n" +
+                "      {\n" +
+                "        \"material\": {\n" +
+                "          \"git-configuration\": {\n" +
+                "            \"shallow-clone\": false,\n" +
+                "            \"branch\": \"branch\",\n" +
+                "            \"url\": \"http://user:******@gitrepo.com\"\n" +
+                "          },\n" +
+                "          \"type\": \"git\"\n" +
+                "        },\n" +
+                "        \"changed\": true,\n" +
+                "        \"modifications\": [\n" +
+                "          {\n" +
+                "            \"revision\": \"1\",\n" +
+                "            \"modified-time\": \"2016-04-06T12:50:03.317+0000\",\n" +
+                "            \"data\": {}\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"material\": {\n" +
+                "          \"mercurial-configuration\": {\n" +
+                "            \"url\": \"http://user:******@hgrepo.com\"\n" +
+                "          },\n" +
+                "          \"type\": \"mercurial\"\n" +
+                "        },\n" +
+                "        \"changed\": true,\n" +
+                "        \"modifications\": [\n" +
+                "          {\n" +
+                "            \"revision\": \"1\",\n" +
+                "            \"modified-time\": \"2016-04-06T12:50:03.317+0000\",\n" +
+                "            \"data\": {}\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"material\": {\n" +
+                "          \"svn-configuration\": {\n" +
+                "            \"username\": \"username\",\n" +
+                "            \"check-externals\": false,\n" +
+                "            \"url\": \"http://user:******@svnrepo.com\"\n" +
+                "          },\n" +
+                "          \"type\": \"svn\"\n" +
+                "        },\n" +
+                "        \"changed\": true,\n" +
+                "        \"modifications\": [\n" +
+                "          {\n" +
+                "            \"revision\": \"1\",\n" +
+                "            \"modified-time\": \"2016-04-06T12:50:03.317+0000\",\n" +
+                "            \"data\": {}\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"material\": {\n" +
+                "          \"tfs-configuration\": {\n" +
+                "            \"username\": \"username\",\n" +
+                "            \"project-path\": \"project-path\",\n" +
+                "            \"domain\": \"domain\",\n" +
+                "            \"url\": \"http://user:******@tfsrepo.com\"\n" +
+                "          },\n" +
+                "          \"type\": \"tfs\"\n" +
+                "        },\n" +
+                "        \"changed\": true,\n" +
+                "        \"modifications\": [\n" +
+                "          {\n" +
+                "            \"revision\": \"1\",\n" +
+                "            \"modified-time\": \"2016-04-06T12:50:03.317+0000\",\n" +
+                "            \"data\": {}\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"material\": {\n" +
+                "          \"perforce-configuration\": {\n" +
+                "            \"username\": \"username\",\n" +
+                "            \"use-tickets\": false,\n" +
+                "            \"view\": \"view\",\n" +
+                "            \"url\": \"127.0.0.1:1666\"\n" +
+                "          },\n" +
+                "          \"type\": \"perforce\"\n" +
+                "        },\n" +
+                "        \"changed\": true,\n" +
+                "        \"modifications\": [\n" +
+                "          {\n" +
+                "            \"revision\": \"1\",\n" +
+                "            \"modified-time\": \"2016-04-06T12:50:03.317+0000\",\n" +
+                "            \"data\": {}\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"material\": {\n" +
+                "          \"pipeline-configuration\": {\n" +
+                "            \"pipeline-name\": \"pipeline-name\",\n" +
+                "            \"stage-name\": \"stage-name\"\n" +
+                "          },\n" +
+                "          \"type\": \"pipeline\"\n" +
+                "        },\n" +
+                "        \"changed\": true,\n" +
+                "        \"modifications\": [\n" +
+                "          {\n" +
+                "            \"revision\": \"pipeline-name/1/stage-name/1\",\n" +
+                "            \"modified-time\": \"2016-04-06T12:50:03.317+0000\",\n" +
+                "            \"data\": {}\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"material\": {\n" +
+                "          \"plugin-id\": \"pluginid\",\n" +
+                "          \"package-configuration\": {\n" +
+                "            \"k3\": \"package-v1\"\n" +
+                "          },\n" +
+                "          \"type\": \"package\",\n" +
+                "          \"repository-configuration\": {\n" +
+                "            \"k1\": \"repo-v1\"\n" +
+                "          }\n" +
+                "        },\n" +
+                "        \"changed\": true,\n" +
+                "        \"modifications\": [\n" +
+                "          {\n" +
+                "            \"revision\": \"1\",\n" +
+                "            \"modified-time\": \"2016-04-06T12:50:03.317+0000\",\n" +
+                "            \"data\": {}\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"material\": {\n" +
+                "          \"plugin-id\": \"pluginid\",\n" +
+                "          \"type\": \"scm\",\n" +
+                "          \"scm-configuration\": {\n" +
+                "            \"k1\": \"v1\"\n" +
+                "          }\n" +
+                "        },\n" +
+                "        \"changed\": true,\n" +
+                "        \"modifications\": [\n" +
+                "          {\n" +
+                "            \"revision\": \"1\",\n" +
+                "            \"modified-time\": \"2016-04-06T12:50:03.317+0000\",\n" +
+                "            \"data\": {}\n" +
+                "          }\n" +
+                "        ]\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"stage\": {\n" +
+                "      \"name\": \"stage-name\",\n" +
+                "      \"counter\": \"1\",\n" +
+                "      \"approval-type\": \"success\",\n" +
+                "      \"approved-by\": \"changes\",\n" +
+                "      \"state\": \"Passed\",\n" +
+                "      \"result\": \"Passed\",\n" +
+                "      \"create-time\": \"2011-07-13T19:43:37.100+0000\",\n" +
+                "      \"last-transition-time\": \"2011-07-13T19:43:37.100+0000\",\n" +
+                "      \"jobs\": [\n" +
+                "        {\n" +
+                "          \"name\": \"job-name\",\n" +
+                "          \"schedule-time\": \"2011-07-13T19:43:37.100+0000\",\n" +
+                "          \"complete-time\": \"2011-07-13T19:43:37.100+0000\",\n" +
+                "          \"state\": \"Completed\",\n" +
+                "          \"result\": \"Passed\",\n" +
+                "          \"agent-uuid\": \"uuid\"\n" +
+                "        }\n" +
+                "      ]\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+        StageStatusRequest stageStatusRequest = StageStatusRequest.fromJSON(json);
 
         Http.pingWebhooks(mockPluginRequest, "stage", stageStatusRequest, mockClient);
 
         verify(mockClient).execute(argThat((HttpPost request) -> {
             try {
+                // Ensure the request is to the correct URL and the content formats the date correctly
                 String content = EntityUtils.toString(request.getEntity());
-                // Ensure the request is to the correct URL and the content is
-                return request.getURI().toString().equals("https://example.com") && content.contains(
-                        "{\"data\":{\"pipeline\":{\"stage\":{\"create-time\":\"2021-01-01T10:12:00.000-0800\"}}},\"type\":\"stage\"}");
+                return request.getURI().toString().equals("https://example.com") && content.contains("\"complete-time\":\"2011-07-13T19:43:37.100+0000\"");
             } catch (Exception e) {
                 return false;
             }


### PR DESCRIPTION
Realized that https://github.com/getsentry/gocd-webhook-notification-plugin/pull/11 didn't work because we write over the serialized dates in the StageStatusRequest objects when sending out the requests in the Http class. Since we are no longer using the default pattern, we shouldn't run into the same formatting issues as we did previously. This will change the format of the dates sent via the webhook.