### PR TITLE
Sentry Integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,10 @@ project.ext.pluginDesc = [
 ]
 
 // Force 1.8 compatibility to ensure that it works with older JVMs
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
 
 // In this section you declare where to find the dependencies of your project
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -29,9 +29,9 @@ project.ext.pluginDesc = [
         vendorUrl  : 'https://github.com/getsentry/webhook-notification-plugin'
 ]
 
-// Force 1.8 compatibility to ensure that it works with older JVMs
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+// Updated to Java 11
+sourceCompatibility = 11
+targetCompatibility = 11
 
 // In this section you declare where to find the dependencies of your project
 repositories {
@@ -47,6 +47,7 @@ dependencies {
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.8.1'
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
     implementation group: 'com.google.cloud', name: 'google-cloud-secretmanager', version: '1.7.2'
+    implementation 'io.sentry:sentry:7.3.0'
 
     testImplementation group: 'junit', name: 'junit', version: '4.12'
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
@@ -69,7 +70,10 @@ processResources {
 }
 
 jar {
-    from(configurations.runtimeClasspath) {
-        into "lib/"
+    // Extract all dependency JARs and merge their contents into this JAR
+    from {
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }
+    // Exclude duplicate files (like META-INF files)
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,13 @@ jar {
     from {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }
-    // Exclude duplicate files (like META-INF files)
+    // Exclude duplicate files, signature files, and problematic classes
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA'
+    exclude 'module-info.class'
+    exclude 'io/grpc/**'
+    exclude '**/Hidden$NettyBlockHoundIntegration.class'
+    exclude '**/Log4J2Logger.class'
+    exclude '**/JettyAlpnSslEngine*.class'
+    exclude '**/JettyNpnSslEngine*.class'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -29,9 +29,9 @@ project.ext.pluginDesc = [
         vendorUrl  : 'https://github.com/getsentry/webhook-notification-plugin'
 ]
 
-// Updated to Java 11
-sourceCompatibility = 11
-targetCompatibility = 11
+// Force 1.8 compatibility to ensure that it works with older JVMs
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 // In this section you declare where to find the dependencies of your project
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -70,17 +70,7 @@ processResources {
 }
 
 jar {
-    // Extract all dependency JARs and merge their contents into this JAR
-    from {
-        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+    from(configurations.runtimeClasspath) {
+        into "lib/"
     }
-    // Exclude duplicate files, signature files, and problematic classes
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    exclude 'META-INF/*.RSA', 'META-INF/*.SF', 'META-INF/*.DSA'
-    exclude 'module-info.class'
-    exclude 'io/grpc/**'
-    exclude '**/Hidden$NettyBlockHoundIntegration.class'
-    exclude '**/Log4J2Logger.class'
-    exclude '**/JettyAlpnSslEngine*.class'
-    exclude '**/JettyNpnSslEngine*.class'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,6 @@ java {
 
 // In this section you declare where to find the dependencies of your project
 repositories {
-    jcenter()
     mavenCentral()
     mavenLocal()
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version = 0.1
+version = 1.2.0

--- a/src/main/java/net/getsentry/gocd/webhooknotifier/WebhookNotifierPlugin.java
+++ b/src/main/java/net/getsentry/gocd/webhooknotifier/WebhookNotifierPlugin.java
@@ -32,11 +32,25 @@ import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 
 import static net.getsentry.gocd.webhooknotifier.Constants.PLUGIN_IDENTIFIER;
+import io.sentry.Sentry;
+import io.sentry.ITransaction;
 
 @Extension
 public class WebhookNotifierPlugin implements GoPlugin {
 
     public static final Logger LOG = Logger.getLoggerFor(WebhookNotifierPlugin.class);
+
+    static {
+        // Hardcoded Sentry configuration
+        Sentry.init(options -> {
+            options.setDsn("https://989fe818e06c640a6688a08a208325ec@o1.ingest.us.sentry.io/4510070253289472");
+            options.setEnvironment("prod");
+            options.setTracesSampleRate(1.0);
+            options.setEnableTracing(true);
+            options.setSendDefaultPii(true);
+        });
+        LOG.info("Sentry initialized for webhook-notifier plugin with tracing enabled");
+    }
 
     private GoApplicationAccessor accessor;
     private PluginRequest pluginRequest;
@@ -49,8 +63,16 @@ public class WebhookNotifierPlugin implements GoPlugin {
 
     @Override
     public GoPluginApiResponse handle(GoPluginApiRequest request) throws UnhandledRequestTypeException {
+        ITransaction transaction = null;
+        Request requestType = Request.fromString(request.requestName());
+        
+        // Start transaction for webhook notification requests
+        if (requestType == Request.REQUEST_STAGE_STATUS || requestType == Request.REQUEST_AGENT_STATUS) {
+            transaction = Sentry.startTransaction("gocd.webhook.handle", request.requestName());
+        }
+        
         try {
-            switch (Request.fromString(request.requestName())) {
+            switch (requestType) {
                 case PLUGIN_SETTINGS_GET_VIEW:
                     return new GetSettingsViewRequestExecutor().execute();
                 case REQUEST_NOTIFICATIONS_INTERESTED_IN:
@@ -70,6 +92,10 @@ public class WebhookNotifierPlugin implements GoPlugin {
         } catch (Exception e) {
             LOG.error("Failed to refresh configuration", e);
             throw new RuntimeException(e);
+        } finally {
+            if (transaction != null) {
+                transaction.finish();
+            }
         }
     }
 

--- a/src/main/java/net/getsentry/gocd/webhooknotifier/WebhookNotifierPlugin.java
+++ b/src/main/java/net/getsentry/gocd/webhooknotifier/WebhookNotifierPlugin.java
@@ -43,7 +43,7 @@ public class WebhookNotifierPlugin implements GoPlugin {
     static {
         Sentry.init(options -> {
             options.setDsn("https://989fe818e06c640a6688a08a208325ec@o1.ingest.us.sentry.io/4510070253289472");
-            options.setEnvironment("prod");
+            options.setEnvironment("production");
             options.setTracesSampleRate(1.0);
             options.setEnableTracing(true);
             options.setSendDefaultPii(true);

--- a/src/main/java/net/getsentry/gocd/webhooknotifier/WebhookNotifierPlugin.java
+++ b/src/main/java/net/getsentry/gocd/webhooknotifier/WebhookNotifierPlugin.java
@@ -41,9 +41,17 @@ public class WebhookNotifierPlugin implements GoPlugin {
     public static final Logger LOG = Logger.getLoggerFor(WebhookNotifierPlugin.class);
 
     static {
+        String hostname = System.getenv("HOSTNAME");
+        final String environment;
+        if (hostname != null && hostname.contains("deploy")) {
+            environment = hostname.contains("staging") ? "staging" : "production";
+        } else {
+            environment = "dev";
+        }
+        
         Sentry.init(options -> {
             options.setDsn("https://989fe818e06c640a6688a08a208325ec@o1.ingest.us.sentry.io/4510070253289472");
-            options.setEnvironment("production");
+            options.setEnvironment(environment);
             options.setTracesSampleRate(1.0);
             options.setEnableTracing(true);
             options.setSendDefaultPii(true);

--- a/src/main/java/net/getsentry/gocd/webhooknotifier/WebhookNotifierPlugin.java
+++ b/src/main/java/net/getsentry/gocd/webhooknotifier/WebhookNotifierPlugin.java
@@ -65,7 +65,6 @@ public class WebhookNotifierPlugin implements GoPlugin {
         ITransaction transaction = null;
         Request requestType = Request.fromString(request.requestName());
         
-        // Start transaction for webhook notification requests
         if (requestType == Request.REQUEST_STAGE_STATUS || requestType == Request.REQUEST_AGENT_STATUS) {
             transaction = Sentry.startTransaction("gocd.webhook.handle", request.requestName());
         }

--- a/src/main/java/net/getsentry/gocd/webhooknotifier/WebhookNotifierPlugin.java
+++ b/src/main/java/net/getsentry/gocd/webhooknotifier/WebhookNotifierPlugin.java
@@ -41,7 +41,6 @@ public class WebhookNotifierPlugin implements GoPlugin {
     public static final Logger LOG = Logger.getLoggerFor(WebhookNotifierPlugin.class);
 
     static {
-        // Hardcoded Sentry configuration
         Sentry.init(options -> {
             options.setDsn("https://989fe818e06c640a6688a08a208325ec@o1.ingest.us.sentry.io/4510070253289472");
             options.setEnvironment("prod");

--- a/src/main/java/net/getsentry/gocd/webhooknotifier/utils/Http.java
+++ b/src/main/java/net/getsentry/gocd/webhooknotifier/utils/Http.java
@@ -73,11 +73,11 @@ public class Http {
         }
 
         ISpan httpPostSpan = webhooksSpan.startChild("http.post");
-        span.setData("webhook.url", url.toString());
+        httpPostSpan.setData("webhook.url", url.toString());
         HttpResponse response = post(url, responseJsonStr, client, headers.toArray(new Header[0]));
         int statusCode = response.getStatusLine().getStatusCode();
-        span.setData("webhook.status_code", statusCode);
-        span.finish();
+        httpPostSpan.setData("webhook.status_code", statusCode);
+        httpPostSpan.finish();
       } catch (Exception e) {
         System.out.printf("    😺 failed to post request to %s with audience %s: %s\n", urlWithAuth.getUrl(), urlWithAuth.getAudience(), e.getMessage());
       }

--- a/src/main/java/net/getsentry/gocd/webhooknotifier/utils/Http.java
+++ b/src/main/java/net/getsentry/gocd/webhooknotifier/utils/Http.java
@@ -55,10 +55,7 @@ public class Http {
     }
 
     URLWithAuth[] urlWithAuths = ps.getWebhooks();
-    ISpan parentSpan = Sentry.getSpan();
-    ISpan webhooksSpan = parentSpan != null ? 
-        parentSpan.startChild("webhook.notification", type) : 
-        Sentry.startTransaction("webhook.notification", type);
+    ISpan webhooksSpan = Sentry.startTransaction("webhook.notification", type);
     
     for (URLWithAuth urlWithAuth : urlWithAuths) {
       try {

--- a/src/main/java/net/getsentry/gocd/webhooknotifier/utils/Http.java
+++ b/src/main/java/net/getsentry/gocd/webhooknotifier/utils/Http.java
@@ -55,7 +55,6 @@ public class Http {
     }
 
     URLWithAuth[] urlWithAuths = ps.getWebhooks();
-    // Get existing transaction or create a new one
     ISpan parentSpan = Sentry.getSpan();
     ISpan webhooksSpan = parentSpan != null ? 
         parentSpan.startChild("webhook.notification", type) : 

--- a/src/main/java/net/getsentry/gocd/webhooknotifier/utils/Http.java
+++ b/src/main/java/net/getsentry/gocd/webhooknotifier/utils/Http.java
@@ -57,7 +57,9 @@ public class Http {
     URLWithAuth[] urlWithAuths = ps.getWebhooks();
     // Get existing transaction or create a new one
     ISpan parentSpan = Sentry.getSpan();
-    ISpan webhooksSpan = parentSpan.startChild("webhook.notification", type);
+    ISpan webhooksSpan = parentSpan != null ? 
+        parentSpan.startChild("webhook.notification", type) : 
+        Sentry.startTransaction("webhook.notification", type);
     
     for (URLWithAuth urlWithAuth : urlWithAuths) {
       try {


### PR DESCRIPTION
Adding minimal but sufficient spans around the entrypoint and webhook requests. Tested and working successfully on: https://gocd-ianwoodard-3.getsentry.net/go/pipelines#!/ 
https://sentry.sentry.io/explore/traces/?project=4510070253289472&statsPeriod=24h

As the plugin runs inside GoCD's JVM, we have limited control over the runtime environment and can't use Sentry's OpenTelemetry agent (which requires -javaagent JVM flags at startup) or Gradle plugin auto-instrumentation, so we manually instrument critical paths instead.

The CI gradle version was upgraded to 9 at some point so the non-Sentry changes in `build.gradle` are just fixing deprecated features (jcenter() removal and java {} block syntax).